### PR TITLE
Disable the super-strict doclint tool in Java 8

### DIFF
--- a/SuperRecyclerView/build.gradle
+++ b/SuperRecyclerView/build.gradle
@@ -22,4 +22,13 @@ dependencies {
     compile 'com.nineoldandroids:library:2.4.0'
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        // disable the crazy super-strict doclint tool in Java 8
+        //noinspection SpellCheckingInspection
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}
+
+
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'


### PR DESCRIPTION
This change prevents from compilation failures when using JDK 8.

More info about: http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html