### PR TITLE
Fix a bug, don't trigger onMoreAsked when adapter has no data or visi…

### DIFF
--- a/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
+++ b/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
@@ -183,7 +183,7 @@ public class SuperRecyclerView extends FrameLayout {
         int totalItemCount = layoutManager.getItemCount();
 
         if (((totalItemCount - lastVisibleItemPosition) <= ITEM_LEFT_TO_LOAD_MORE ||
-             (totalItemCount - lastVisibleItemPosition) == 0 && totalItemCount > visibleItemCount)
+             (totalItemCount - lastVisibleItemPosition) == 0) && (totalItemCount > visibleItemCount)
             && !isLoadingMore) {
 
             isLoadingMore = true;


### PR DESCRIPTION
Hi, i found two problem when using SuperRecyclerView.
First, there is no necessary to trigger api{#link onMoreAsked()} when adapter has no data or visibleItemCount equal totalItemCount, i have fixed in my fork project from you repo.
Second, i suggest you invoke api{#link processOnMore()}  when scroll state equal RecyclerView.SCROLL_STATE_IDLE, because sometimes api{#link onMoreAsked()} always trigger loadingMore  after scroll down.My suggest code like below:

@Override
 public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
                    super.onScrollStateChanged(recyclerView, newState);
                    if(newState == RecyclerView.SCROLL_STATE_IDLE) {
                        processOnMore();
                    }
}