### PR TITLE
Empty layout :IllegalArgumentException

### DIFF
--- a/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
+++ b/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
@@ -296,9 +296,11 @@ public class SuperRecyclerView extends FrameLayout {
                 }
             });
 
-        mEmpty.setVisibility(null != adapter && adapter.getItemCount() > 0 && mEmptyId != 0
-                             ? View.GONE
-                             : View.VISIBLE);
+        if (mEmptyId != 0) {
+            mEmpty.setVisibility(null != adapter && adapter.getItemCount() > 0
+                    ? View.GONE
+                    : View.VISIBLE);
+        }
     }
 
     /**


### PR DESCRIPTION
if emptyId is null,when setAdapterInternal mEmpty did not check it.so creat a "java.lang.IllegalArgumentException: ViewStub must have a valid layoutResource"