### PR TITLE
Reduce switch case clauses number of lines to increase the readability

### DIFF
--- a/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
+++ b/SuperRecyclerView/src/main/java/com/malinskiy/superrecyclerview/SuperRecyclerView.java
@@ -216,16 +216,21 @@ public class SuperRecyclerView extends FrameLayout {
                 lastVisibleItemPosition = ((GridLayoutManager) layoutManager).findLastVisibleItemPosition();
                 break;
             case STAGGERED_GRID:
-                StaggeredGridLayoutManager staggeredGridLayoutManager = (StaggeredGridLayoutManager) layoutManager;
-                if (lastScrollPositions == null)
-                    lastScrollPositions = new int[staggeredGridLayoutManager.getSpanCount()];
-
-                staggeredGridLayoutManager.findLastVisibleItemPositions(lastScrollPositions);
-                lastVisibleItemPosition = findMax(lastScrollPositions);
+                lastVisibleItemPosition = caseStaggeredGrid();
                 break;
         }
         return lastVisibleItemPosition;
     }
+
+    private int caseStaggeredGrid() {
+        StaggeredGridLayoutManager staggeredGridLayoutManager = (StaggeredGridLayoutManager) layoutManager;
+        if (lastScrollPositions == null)
+            lastScrollPositions = new int[staggeredGridLayoutManager.getSpanCount()];
+
+        staggeredGridLayoutManager.findLastVisibleItemPositions(lastScrollPositions);
+        return findMax(lastScrollPositions);
+    }
+
 
     private int findMax(int[] lastPositions) {
         int max = Integer.MIN_VALUE;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1151 - “ "switch case" clauses should not have too many lines”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1151
Please let me know if you have any questions.
Ayman Abdelghany.